### PR TITLE
Fix compilation issue on recent compilers

### DIFF
--- a/AviStrList.h
+++ b/AviStrList.h
@@ -110,6 +110,7 @@ union _avistreamformat {
 #define AVI_INDEX_IS_DATA    0x80
 
 struct _aviindex_entry {
+  int dummy;
   uint32_t adw[];
 } __attribute__ ((packed));
 


### PR DESCRIPTION
hello
pulling back my old cowon players for a project, i'm happy to see your useful code for converting videos.

on today compilers it gives error : 
./AviStrList.h:113:12: error: flexible array member ‘_aviindex_entry::adw’ in an otherwise empty ‘struct _aviindex_entry’

hence i added a dummy var in order to please the compiler.
